### PR TITLE
Fixed generics parsing

### DIFF
--- a/example/cli.plm
+++ b/example/cli.plm
@@ -6,8 +6,21 @@ fn counter(n: int) {
   }
 }
 
+fn update<A>(mut x: A, f: fn(A): A) {
+  x = f(*x)
+  return unit
+}
+
 c = counter(2)
 println(c().show())
 println(c().show())
 println(c().show())
 println(c().show())
+
+mut x = 0
+
+println(x->show())
+
+update(x, fn(_) => 3)
+
+println(x->show())

--- a/src/Plume/Syntax/Parser/Parser.hs
+++ b/src/Plume/Syntax/Parser/Parser.hs
@@ -216,6 +216,7 @@ sFunction :: P.Parser CST.Expression
 sFunction = do
   void $ L.reserved "fn"
   name <- L.identifier
+  generics <- P.option [] $ L.angles $ Typ.parseGeneric `P.sepBy` L.comma
   args <- L.parens $ mutArg `P.sepBy` L.comma
   retTy <- P.optional $ L.symbol ":" *> Typ.tType
   body <- L.symbol "=>" *> parseExpression <|> eBlock
@@ -224,7 +225,7 @@ sFunction = do
 
   return $
     CST.EDeclaration
-      []
+      generics
       False
       (name Cmm.:@: Nothing)
       cl


### PR DESCRIPTION
Fixed generics parsing on function definitions just by adding the missing case in the parser.